### PR TITLE
Update hand_tracking.tox

### DIFF
--- a/toxes/hand_tracking.tox
+++ b/toxes/hand_tracking.tox
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36c2d618d41272d8ebc1d5d0baa1794129384003fe0b2b611174f09879fdb7d8
-size 33958
+oid sha256:92d33ab632e9e3f333d9d2f4d4317073814c547c1acb1fa3741a0f80954b0a83
+size 55558


### PR DESCRIPTION
Fixes and QOL updates to the hand_tracking.tox

- Added "active channel" to instance_data
- instance_data channels are now aspect correct normalized values that can be rendered in other 16:9 resolutions
- point_render now renders circle SOPs

Changes to velocity calculation comps:
- Changed velocity channel names to align with h*: naming convention
- Added hand active channels
- Added gating to the the hand velocity calculation to avoid spikes on hand entry and exit. This includes setting a number of frames to wait before engaging velocity, which can be needed to ignore initial discontinuities. ("Entry Frame Ignore")
- Added "Ignore Frames in Active Chan" toggle that can include the ignore frames in hand_active channels if desired.
- velocity_h2 is now a clone of velocity_h1 
