### PR TITLE
Check if client exists before checking if it needs to be closed

### DIFF
--- a/td_scripts/Media_Pipe/webserver_callbacks.py
+++ b/td_scripts/Media_Pipe/webserver_callbacks.py
@@ -67,8 +67,9 @@ def onWebSocketOpen(webServerDAT, client, uri):
 	return
 
 def onWebSocketClose(webServerDAT, client):
-	if(clients[client]):
-		del clients[client]
+	if client in clients:
+		if clients[client]:
+			del clients[client]
 	return
 
 def onWebSocketReceiveText(webServerDAT, client, data):


### PR DESCRIPTION
Sometimes this would check for a client that doesn't exist (specifically on load), so we need to check if it actually exists first.